### PR TITLE
Improve opentypes and add more modules

### DIFF
--- a/pyasn1_modules/rfc2040.py
+++ b/pyasn1_modules/rfc2040.py
@@ -1,0 +1,41 @@
+#
+# This file is part of pyasn1-modules software.
+#
+# Created by Russ Housley.
+#
+# Copyright (c) 2021, Vigil Security, LLC
+# License: http://snmplabs.com/pyasn1/license.html
+#
+# Identifiers for RC5
+#
+# ASN.1 source from:
+# https://www.rfc-editor.org/rfc/rfc2040.txt
+# https://www.rfc-editor.org/rfc/rfc8018.txt
+#
+
+from pyasn1_modules import rfc5280
+from pyasn1_modules import rfc8018
+
+
+# The some RC5 object identifiers are defined in RFC 8018
+
+encryptionAlgorithm = rfc8018.encryptionAlgorithm
+
+rc5_CBC = encryptionAlgorithm + (8, )
+
+rc5_CBC_PAD = rfc8018.rc5_CBC_PAD
+
+
+# The RC5 CBC parameters are defined in RFC 8018
+
+RC5_CBC_Parameters = rfc8018.RC5_CBC_Parameters
+
+
+# Update the Algorithm Identifier map for the one not already handled
+# by importing rfc8018.
+
+_algorithmIdentifierMapUpdate = {
+    rc5_CBC: RC5_CBC_Parameters(),
+}
+
+rfc5280.algorithmIdentifierMap.update(_algorithmIdentifierMapUpdate)

--- a/pyasn1_modules/rfc2528.py
+++ b/pyasn1_modules/rfc2528.py
@@ -1,0 +1,34 @@
+#
+# This file is part of pyasn1-modules.
+#
+# Created by Russ Housley.
+#
+# Copyright (c) 2021, Vigil Security, LLC
+# License: http://snmplabs.com/pyasn1/license.html
+#
+# Identifiers for the Key Exchange Algorithm (KEA)
+#
+# ASN.1 source from:
+# https://www.rfc-editor.org/rfc/rfc2528.txt
+# https://www.rfc-editor.org/rfc/rfc3279.txt
+#
+
+from pyasn1_modules import rfc3279
+
+
+# The KEA object identifier is defined in RFC 3279
+
+id_keyExchangeAlgorithm = rfc3279. id_keyExchangeAlgorithm
+
+
+# The KEA parameters structure is defined in RFC 3279
+
+KEA_Parms_Id = rfc3279.KEA_Parms_Id
+
+
+# The Algorithm Identifier map is updated by importing rfc3279.
+# To save looking it up, the map is updated with this entry:
+#
+# _algorithmIdentifierMapUpdate = {
+#     id_keyExchangeAlgorithm: KEA_Parms_Id(),
+# }

--- a/pyasn1_modules/rfc3217.py
+++ b/pyasn1_modules/rfc3217.py
@@ -1,0 +1,42 @@
+#
+# This file is part of pyasn1-modules software.
+#
+# Created by Russ Housley.
+#
+# Copyright (c) 2021, Vigil Security, LLC
+# License: http://snmplabs.com/pyasn1/license.html
+#
+# Triple-DES and RC2 Key Wrapping 
+#
+# ASN.1 source from:
+# https://www.rfc-editor.org/rfc/rfc3217.txt
+# https://www.rfc-editor.org/rfc/rfc3370.txt
+# https://www.rfc-editor.org/rfc/rfc5990.txt
+#
+
+from pyasn1_modules import rfc3370
+from pyasn1_modules import rfc5990
+
+
+# Imports from RFC 3370
+
+id_alg_CMSRC2wrap = rfc3370.id_alg_CMSRC2wrap
+
+RC2ParameterVersion = rfc3370.RC2ParameterVersion
+
+RC2wrapParameter = rfc3370.RC2wrapParameter
+
+
+# Imports from RFC 5990
+
+id_alg_CMS3DESwrap = rfc5990.id_alg_CMS3DESwrap
+
+
+# The update to the Algorithm Identifier map is already handled
+# by importing rfc3370 and rfc5990. To save looking it up, the
+# map is updated with these entries:
+#
+# _algorithmIdentifierMapUpdate = {
+#     id_alg_CMS3DESwrap: univ.Null(),
+#     id_alg_CMSRC2wrap: RC2wrapParameter(),
+# }

--- a/pyasn1_modules/rfc3874.py
+++ b/pyasn1_modules/rfc3874.py
@@ -1,0 +1,29 @@
+#
+# This file is part of pyasn1-modules software.
+#
+# Created by Russ Housley.
+#
+# Copyright (c) 2021, Vigil Security, LLC
+# License: http://snmplabs.com/pyasn1/license.html
+#
+# Identifiers for RC5
+#
+# ASN.1 source from:
+# https://www.rfc-editor.org/rfc/rfc3874.txt
+# https://www.rfc-editor.org/rfc/rfc5990.txt
+#
+
+from pyasn1_modules import rfc5990
+
+
+# Import from RFC 4055
+
+id_sha224 = rfc5990.id_sha224
+
+
+# The Algorithm Identifier map is updated by importing rfc5990.
+# To save looking it up, the map is updated with this entry:
+#
+# _algorithmIdentifierMapUpdate = {
+#     id_sha224: univ.Null(),
+# }

--- a/pyasn1_modules/rfc4211.py
+++ b/pyasn1_modules/rfc4211.py
@@ -3,6 +3,7 @@
 # This file is part of pyasn1-modules software.
 #
 # Created by Stanisław Pitucha with asn1ate tool.
+# Modified by Russ Housley to add support for opentypes.
 # Copyright (c) 2005-2020, Ilya Etingof <etingof@gmail.com>
 # License: http://snmplabs.com/pyasn1/license.html
 #
@@ -10,7 +11,7 @@
 # Message Format (CRMF)
 #
 # ASN.1 source from:
-# http://www.ietf.org/rfc/rfc4211.txt
+# http://www.rfc-editor.org/rfc/rfc4211.txt
 #
 from pyasn1.type import char
 from pyasn1.type import constraint
@@ -19,8 +20,8 @@ from pyasn1.type import namedval
 from pyasn1.type import tag
 from pyasn1.type import univ
 
-from pyasn1_modules import rfc3280
-from pyasn1_modules import rfc3852
+from pyasn1_modules import rfc5280
+from pyasn1_modules import rfc5652
 
 MAX = float('inf')
 
@@ -50,7 +51,7 @@ class SinglePubInfo(univ.Sequence):
 SinglePubInfo.componentType = namedtype.NamedTypes(
     namedtype.NamedType('pubMethod', univ.Integer(
         namedValues=namedval.NamedValues(('dontCare', 0), ('x500', 1), ('web', 2), ('ldap', 3)))),
-    namedtype.OptionalNamedType('pubLocation', rfc3280.GeneralName())
+    namedtype.OptionalNamedType('pubLocation', rfc5280.GeneralName())
 )
 
 
@@ -63,7 +64,7 @@ class PKMACValue(univ.Sequence):
 
 
 PKMACValue.componentType = namedtype.NamedTypes(
-    namedtype.NamedType('algId', rfc3280.AlgorithmIdentifier()),
+    namedtype.NamedType('algId', rfc5280.AlgorithmIdentifier()),
     namedtype.NamedType('value', univ.BitString())
 )
 
@@ -77,7 +78,7 @@ POPOSigningKeyInput.componentType = namedtype.NamedTypes(
         'authInfo', univ.Choice(
             componentType=namedtype.NamedTypes(
                 namedtype.NamedType(
-                    'sender', rfc3280.GeneralName().subtype(implicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatConstructed, 0))
+                    'sender', rfc5280.GeneralName().subtype(implicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatConstructed, 0))
                 ),
                 namedtype.NamedType(
                     'publicKeyMAC', PKMACValue()
@@ -85,7 +86,7 @@ POPOSigningKeyInput.componentType = namedtype.NamedTypes(
             )
         )
     ),
-    namedtype.NamedType('publicKey', rfc3280.SubjectPublicKeyInfo())
+    namedtype.NamedType('publicKey', rfc5280.SubjectPublicKeyInfo())
 )
 
 
@@ -96,7 +97,7 @@ class POPOSigningKey(univ.Sequence):
 POPOSigningKey.componentType = namedtype.NamedTypes(
     namedtype.OptionalNamedType('poposkInput', POPOSigningKeyInput().subtype(
         implicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatConstructed, 0))),
-    namedtype.NamedType('algorithmIdentifier', rfc3280.AlgorithmIdentifier()),
+    namedtype.NamedType('algorithmIdentifier', rfc5280.AlgorithmIdentifier()),
     namedtype.NamedType('signature', univ.BitString())
 )
 
@@ -105,7 +106,7 @@ class Attributes(univ.SetOf):
     pass
 
 
-Attributes.componentType = rfc3280.Attribute()
+Attributes.componentType = rfc5280.Attribute()
 
 
 class PrivateKeyInfo(univ.Sequence):
@@ -114,7 +115,7 @@ class PrivateKeyInfo(univ.Sequence):
 
 PrivateKeyInfo.componentType = namedtype.NamedTypes(
     namedtype.NamedType('version', univ.Integer()),
-    namedtype.NamedType('privateKeyAlgorithm', rfc3280.AlgorithmIdentifier()),
+    namedtype.NamedType('privateKeyAlgorithm', rfc5280.AlgorithmIdentifier()),
     namedtype.NamedType('privateKey', univ.OctetString()),
     namedtype.OptionalNamedType('attributes',
                                 Attributes().subtype(implicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatSimple, 0)))
@@ -126,13 +127,13 @@ class EncryptedValue(univ.Sequence):
 
 
 EncryptedValue.componentType = namedtype.NamedTypes(
-    namedtype.OptionalNamedType('intendedAlg', rfc3280.AlgorithmIdentifier().subtype(
+    namedtype.OptionalNamedType('intendedAlg', rfc5280.AlgorithmIdentifier().subtype(
         implicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatSimple, 0))),
-    namedtype.OptionalNamedType('symmAlg', rfc3280.AlgorithmIdentifier().subtype(
+    namedtype.OptionalNamedType('symmAlg', rfc5280.AlgorithmIdentifier().subtype(
         implicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatSimple, 1))),
     namedtype.OptionalNamedType('encSymmKey', univ.BitString().subtype(
         implicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatSimple, 2))),
-    namedtype.OptionalNamedType('keyAlg', rfc3280.AlgorithmIdentifier().subtype(
+    namedtype.OptionalNamedType('keyAlg', rfc5280.AlgorithmIdentifier().subtype(
         implicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatSimple, 3))),
     namedtype.OptionalNamedType('valueHint', univ.OctetString().subtype(
         implicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatSimple, 4))),
@@ -146,7 +147,7 @@ class EncryptedKey(univ.Choice):
 
 EncryptedKey.componentType = namedtype.NamedTypes(
     namedtype.NamedType('encryptedValue', EncryptedValue()),
-    namedtype.NamedType('envelopedData', rfc3852.EnvelopedData().subtype(
+    namedtype.NamedType('envelopedData', rfc5652.EnvelopedData().subtype(
         implicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatSimple, 0)))
 )
 
@@ -175,7 +176,7 @@ id_regInfo = _buildOid(id_pkip, 2)
 id_regInfo_certReq = _buildOid(id_regInfo, 2)
 
 
-class ProtocolEncrKey(rfc3280.SubjectPublicKeyInfo):
+class ProtocolEncrKey(rfc5280.SubjectPublicKeyInfo):
     pass
 
 
@@ -216,7 +217,7 @@ POPOPrivKey.componentType = namedtype.NamedTypes(
                         univ.BitString().subtype(implicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatSimple, 2))),
     namedtype.NamedType('agreeMAC',
                         PKMACValue().subtype(implicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatConstructed, 3))),
-    namedtype.NamedType('encryptedKey', rfc3852.EnvelopedData().subtype(
+    namedtype.NamedType('encryptedKey', rfc5652.EnvelopedData().subtype(
         implicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatSimple, 4)))
 )
 
@@ -242,9 +243,9 @@ class OptionalValidity(univ.Sequence):
 
 
 OptionalValidity.componentType = namedtype.NamedTypes(
-    namedtype.OptionalNamedType('notBefore', rfc3280.Time().subtype(
+    namedtype.OptionalNamedType('notBefore', rfc5280.Time().subtype(
         implicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatConstructed, 0))),
-    namedtype.OptionalNamedType('notAfter', rfc3280.Time().subtype(
+    namedtype.OptionalNamedType('notAfter', rfc5280.Time().subtype(
         implicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatConstructed, 1)))
 )
 
@@ -254,25 +255,25 @@ class CertTemplate(univ.Sequence):
 
 
 CertTemplate.componentType = namedtype.NamedTypes(
-    namedtype.OptionalNamedType('version', rfc3280.Version().subtype(
+    namedtype.OptionalNamedType('version', rfc5280.Version().subtype(
         implicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatSimple, 0))),
     namedtype.OptionalNamedType('serialNumber', univ.Integer().subtype(
         implicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatSimple, 1))),
-    namedtype.OptionalNamedType('signingAlg', rfc3280.AlgorithmIdentifier().subtype(
+    namedtype.OptionalNamedType('signingAlg', rfc5280.AlgorithmIdentifier().subtype(
         implicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatSimple, 2))),
-    namedtype.OptionalNamedType('issuer', rfc3280.Name().subtype(
+    namedtype.OptionalNamedType('issuer', rfc5280.Name().subtype(
         implicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatConstructed, 3))),
     namedtype.OptionalNamedType('validity', OptionalValidity().subtype(
         implicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatConstructed, 4))),
-    namedtype.OptionalNamedType('subject', rfc3280.Name().subtype(
+    namedtype.OptionalNamedType('subject', rfc5280.Name().subtype(
         implicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatConstructed, 5))),
-    namedtype.OptionalNamedType('publicKey', rfc3280.SubjectPublicKeyInfo().subtype(
+    namedtype.OptionalNamedType('publicKey', rfc5280.SubjectPublicKeyInfo().subtype(
         implicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatSimple, 6))),
-    namedtype.OptionalNamedType('issuerUID', rfc3280.UniqueIdentifier().subtype(
+    namedtype.OptionalNamedType('issuerUID', rfc5280.UniqueIdentifier().subtype(
         implicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatSimple, 7))),
-    namedtype.OptionalNamedType('subjectUID', rfc3280.UniqueIdentifier().subtype(
+    namedtype.OptionalNamedType('subjectUID', rfc5280.UniqueIdentifier().subtype(
         implicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatSimple, 8))),
-    namedtype.OptionalNamedType('extensions', rfc3280.Extensions().subtype(
+    namedtype.OptionalNamedType('extensions', rfc5280.Extensions().subtype(
         implicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatSimple, 9)))
 )
 
@@ -327,7 +328,7 @@ class CertId(univ.Sequence):
 
 
 CertId.componentType = namedtype.NamedTypes(
-    namedtype.NamedType('issuer', rfc3280.GeneralName()),
+    namedtype.NamedType('issuer', rfc5280.GeneralName()),
     namedtype.NamedType('serialNumber', univ.Integer())
 )
 
@@ -357,7 +358,7 @@ EncKeyWithID.componentType = namedtype.NamedTypes(
         'identifier', univ.Choice(
             componentType=namedtype.NamedTypes(
                 namedtype.NamedType('string', char.UTF8String()),
-                namedtype.NamedType('generalName', rfc3280.GeneralName())
+                namedtype.NamedType('generalName', rfc5280.GeneralName())
             )
         )
     )
@@ -376,9 +377,9 @@ class PBMParameter(univ.Sequence):
 
 PBMParameter.componentType = namedtype.NamedTypes(
     namedtype.NamedType('salt', univ.OctetString()),
-    namedtype.NamedType('owf', rfc3280.AlgorithmIdentifier()),
+    namedtype.NamedType('owf', rfc5280.AlgorithmIdentifier()),
     namedtype.NamedType('iterationCount', univ.Integer()),
-    namedtype.NamedType('mac', rfc3280.AlgorithmIdentifier())
+    namedtype.NamedType('mac', rfc5280.AlgorithmIdentifier())
 )
 
 id_regCtrl_regToken = _buildOid(id_regCtrl, 1)

--- a/pyasn1_modules/rfc4231.py
+++ b/pyasn1_modules/rfc4231.py
@@ -1,0 +1,38 @@
+#
+# This file is part of pyasn1-modules software.
+#
+# Created by Russ Housley.
+#
+# Copyright (c) 2020, Vigil Security, LLC
+# License: http://snmplabs.com/pyasn1/license.html
+#
+# Identifiers for HMAC-SHA-224, HMAC-SHA-256, HMAC-SHA-384,
+#   and HMAC-SHA-512
+#
+# ASN.1 source from:
+# https://www.rfc-editor.org/rfc/rfc4231.txt
+# https://www.rfc-editor.org/rfc/rfc8018.txt
+#
+
+from pyasn1_modules import rfc8018
+
+
+# The HMAC object identifiers are already defined in RFC 8018
+
+id_hmacWithSHA224 = rfc8018.id_hmacWithSHA224
+
+id_hmacWithSHA256 = rfc8018.id_hmacWithSHA256
+
+id_hmacWithSHA384 = rfc8018.id_hmacWithSHA384
+
+id_hmacWithSHA512 = rfc8018.id_hmacWithSHA512
+
+
+# The Algorithm Identifier map is updated by importing rfc8018.
+# To save looking it up, the map is updated with these entries:
+#  _algorithmIdentifierMapUpdate = {
+#     id_hmacWithSHA224: univ.Null(),
+#     id_hmacWithSHA256: univ.Null(),
+#     id_hmacWithSHA384: univ.Null(),
+#     id_hmacWithSHA512: univ.Null(),
+#  }

--- a/pyasn1_modules/rfc5990.py
+++ b/pyasn1_modules/rfc5990.py
@@ -2,6 +2,7 @@
 # This file is part of pyasn1-modules software.
 #
 # Created by Russ Housley with assistance from asn1ate v.0.6.0.
+# Updated by Russ Housley to update the SMIMECapabilities map.
 #
 # Copyright (c) 2019, Vigil Security, LLC
 # License: http://snmplabs.com/pyasn1/license.html
@@ -17,6 +18,7 @@ from pyasn1.type import namedtype
 from pyasn1.type import univ
 
 from pyasn1_modules import rfc5280
+from pyasn1_modules import rfc5751
 
 MAX = float('inf')
 
@@ -218,10 +220,11 @@ camellia256_Wrap['algorithm'] = id_camellia256_Wrap
 # camellia256_Wrap['parameters'] are absent
 
 
-# Update the Algorithm Identifier map in rfc5280.py.
-# Note that the ones that must not have parameters are not added to the map.
+# Update the Algorithm Identifier map in rfc5280.py and the
+# S/MIME Capabilities map in rfc5751.py. Note that the algorithm
+# identifiers that must not have parameters are not added to the maps.
 
-_algorithmIdentifierMapUpdate = {
+_mapUpdate = {
     id_rsa_kem: GenericHybridParameters(),
     id_kem_rsa: RsaKemParameters(),
     id_kdf_kdf2: KDF2_HashFunction(),
@@ -234,4 +237,5 @@ _algorithmIdentifierMapUpdate = {
     id_alg_CMS3DESwrap: univ.Null(),
 }
 
-rfc5280.algorithmIdentifierMap.update(_algorithmIdentifierMapUpdate)
+rfc5280.algorithmIdentifierMap.update(_mapUpdate)
+rfc5751.smimeCapabilityMap.update(_mapUpdate)

--- a/pyasn1_modules/rfc6484.py
+++ b/pyasn1_modules/rfc6484.py
@@ -1,0 +1,17 @@
+#
+# This file is part of pyasn1-modules software.
+#
+# Created by Russ Housley.
+#
+# Copyright (c) 2020, Vigil Security, LLC
+# License: http://snmplabs.com/pyasn1/license.html
+#
+# RPKI Certificate Policy Identifier
+#
+# ASN.1 source from:
+# https://www.rfc-editor.org/rfc/rfc6484.txt
+#
+
+from pyasn1.type import univ
+
+id_cp_ipAddr_asNumber = univ.ObjectIdentifier('1.3.6.1.5.5.7.14.2')

--- a/pyasn1_modules/rfc6494.py
+++ b/pyasn1_modules/rfc6494.py
@@ -1,0 +1,23 @@
+#
+# This file is part of pyasn1-modules software.
+#
+# Created by Russ Housley.
+#
+# Copyright (c) 2020, Vigil Security, LLC
+# License: http://snmplabs.com/pyasn1/license.html
+#
+# Certificate Profile and Certificate Management for
+# SEcure Neighbor Discovery (SEND)
+#
+# ASN.1 source from:
+# https://www.rfc-editor.org/rfc/rfc6494.txt
+#
+
+from pyasn1.type import univ
+
+id_kp = univ.ObjectIdentifier('1.3.6.1.5.5.7.3')
+
+id_kp_sendOwner = id_kp + (25, )
+id_kp_sendProxiedOwner = id_kp + (26, )
+id_kp_sendProxiedRouter = id_kp + (24, )
+id_kp_sendRouter = id_kp + (23, )

--- a/pyasn1_modules/rfc6960.py
+++ b/pyasn1_modules/rfc6960.py
@@ -3,13 +3,14 @@
 #
 # Created by Russ Housley.
 #
-# Copyright (c) 2019, Vigil Security, LLC
+# Copyright (c) 2020, Vigil Security, LLC
 # License: http://snmplabs.com/pyasn1/license.html
 #
 # Online Certificate Status Protocol (OCSP)
 #
 # ASN.1 source from:
 # https://www.rfc-editor.org/rfc/rfc6960.txt
+# https://www.rfc-editor.org/rfc/rfc8984.txt
 #
 
 from pyasn1.type import univ, char, namedtype, namedval, tag, constraint, useful
@@ -65,6 +66,12 @@ id_pkix_ocsp_service_locator = rfc2560.id_pkix_ocsp_service_locator
 
 id_pkix_ocsp_pref_sig_algs = id_pkix_ocsp + (8, )
 id_pkix_ocsp_extended_revoke = id_pkix_ocsp + (9, )
+
+
+# Nonce from RFC 8984
+
+class Nonce(univ.OctetString):
+    subtypeSpec = constraint.ValueSizeConstraint(1, 32)
 
 
 # Updated structures (mostly to improve openTypes support)
@@ -195,7 +202,6 @@ class PreferredSignatureAlgorithms(univ.SequenceOf):
     componentType = PreferredSignatureAlgorithm()
 
 
-
 # Response Type OID to Response Map
 
 ocspResponseMap = {
@@ -210,7 +216,7 @@ _certificateExtensionsMapUpdate = {
     # Certificate Extension
     id_pkix_ocsp_nocheck: univ.Null(""),
     # OCSP Request Extensions
-    id_pkix_ocsp_nonce: univ.OctetString(),
+    id_pkix_ocsp_nonce: Nonce(),
     id_pkix_ocsp_response: AcceptableResponses(),
     id_pkix_ocsp_service_locator: ServiceLocator(),
     id_pkix_ocsp_pref_sig_algs: PreferredSignatureAlgorithms(),

--- a/pyasn1_modules/rfc8018.py
+++ b/pyasn1_modules/rfc8018.py
@@ -34,6 +34,7 @@ def _OID(*components):
 
 
 # Import from RFC 3565
+# Initialization Vector for AES: OCTET STRING (SIZE(16))
 
 AES_IV = rfc3565.AES_IV
 
@@ -205,14 +206,6 @@ RC5_CBC_Parameters.componentType = namedtype.NamedTypes(
         univ.Integer().subtype(subtypeSpec=constraint.SingleValueConstraint(64, 128))),
     namedtype.OptionalNamedType('iv', univ.OctetString())
 )
-
-
-# Initialization Vector for AES: OCTET STRING (SIZE(16))
-
-class AES_IV(univ.OctetString):
-    pass
-
-AES_IV.subtypeSpec = constraint.ValueSizeConstraint(16, 16)
 
 
 # Initialization Vector for DES: OCTET STRING (SIZE(8))

--- a/pyasn1_modules/rfc8737.py
+++ b/pyasn1_modules/rfc8737.py
@@ -1,0 +1,34 @@
+#
+# This file is part of pyasn1-modules software.
+#
+# Created by Russ Housley.
+#
+# Copyright (c) 2020, Vigil Security, LLC
+# License: http://snmplabs.com/pyasn1/license.html
+#
+# ACME TLS ALPN Challenge Certificate Extension
+#
+# ASN.1 source from:
+# https://www.rfc-editor.org/rfc/rfc8737.txt
+#
+
+from pyasn1.type import univ
+from pyasn1.type import constraint
+
+from pyasn1_modules import rfc5280
+
+
+id_pe_acmeIdentifier = univ.ObjectIdentifier((1, 3, 6, 1, 5, 5, 7, 1, 31))
+
+class Authorization(univ.OctetString):
+    subtypeSpec = constraint.ValueSizeConstraint(32, 32)
+
+
+# Map of Certificate Extension OIDs to Extensions added to the
+# ones that are in rfc5280.py
+
+_certificateExtensionsMapUpdate = {
+    id_pe_acmeIdentifier: Authorization(),	
+}
+
+rfc5280.certificateExtensionsMap.update(_certificateExtensionsMapUpdate)

--- a/pyasn1_modules/rfc8894.py
+++ b/pyasn1_modules/rfc8894.py
@@ -1,0 +1,52 @@
+#
+# This file is part of pyasn1-modules software.
+#
+# Created by Russ Housley.
+#
+# Copyright (c) 2020, Vigil Security, LLC
+# License: http://snmplabs.com/pyasn1/license.html
+#
+# Simple Certificate Enrolment Protocol
+#
+# ASN.1 source from:
+# https://www.rfc-editor.org/rfc/rfc8894.txt
+#
+
+from pyasn1.type import univ
+from pyasn1.type import namedtype
+
+from pyasn1_modules import rfc5280
+
+
+# Object Identifiers
+   
+id_VeriSign = univ.ObjectIdentifier((2, 16, 840, 1, 113733))
+
+id_pki = id_VeriSign + (1, )
+
+id_attributes = id_pki + (9, )
+
+id_transactionID = id_attributes + (7, )
+
+id_messageType = id_attributes + (2, )
+
+id_pkiStatus = id_attributes + (3, )
+
+id_failInfo = id_attributes + (4, )
+
+id_senderNonce = id_attributes + (5, )
+
+id_recipientNonce  = id_attributes + (6, )
+
+id_scep = univ.ObjectIdentifier((1, 3, 6, 1, 5, 5, 7, 24))
+
+id_scep_failInfoText = id_scep + (1, )   
+
+
+# Structures
+
+class IssuerAndSubject(univ.Sequence):
+    componentType = namedtype.NamedTypes(
+        namedtype.NamedType('issuer', rfc5280.Name()),
+        namedtype.NamedType('subject', rfc5280.Name())
+    )

--- a/pyasn1_modules/rfc8951.py
+++ b/pyasn1_modules/rfc8951.py
@@ -1,0 +1,42 @@
+#
+# This file is part of pyasn1-modules software.
+#
+# Created by Russ Housley.
+#
+# Copyright (c) 2020, Vigil Security, LLC
+# License: http://snmplabs.com/pyasn1/license.html
+#
+# Enrollment over Secure Transport (EST) Clarifications
+#
+# ASN.1 source from:
+# https://www.rfc-editor.org/rfc/rfc8951.txt
+#
+
+from pyasn1_modules import rfc5652
+from pyasn1_modules import rfc7030
+
+
+# Imports from RFC 5652
+
+Attribute = rfc5652.Attribute
+
+
+# Imports from RFC 7030
+
+id_aa_asymmDecryptKeyID = rfc7030.id_aa_asymmDecryptKeyID
+
+AsymmetricDecryptKeyIdentifier = rfc7030.AsymmetricDecryptKeyIdentifier
+
+AttrOrOID = rfc7030.AttrOrOID
+
+CsrAttrs = rfc7030.CsrAttrs
+
+
+# Asymmetric Decrypt Key Identifier Attribute
+
+aa_asymmDecryptKeyID = Attribute()
+aa_asymmDecryptKeyID['attrType'] = id_aa_asymmDecryptKeyID
+aa_asymmDecryptKeyID['attrValues'][0] = AsymmetricDecryptKeyIdentifier()
+
+
+# Note that the update CMS Attribute Map is handled by importing rfc7030

--- a/tests/__main__.py
+++ b/tests/__main__.py
@@ -8,11 +8,13 @@ import unittest
 
 suite = unittest.TestLoader().loadTestsFromNames(
     ['tests.test_pem.suite',
+     'tests.test_rfc2040.suite',
      'tests.test_rfc2314.suite',
      'tests.test_rfc2315.suite',
      'tests.test_rfc2437.suite',
      'tests.test_rfc2459.suite',
      'tests.test_rfc2511.suite',
+     'tests.test_rfc2528.suite',
      'tests.test_rfc2560.suite',
      'tests.test_rfc2631.suite',
      'tests.test_rfc2634.suite',
@@ -23,6 +25,7 @@ suite = unittest.TestLoader().loadTestsFromNames(
      'tests.test_rfc3114.suite',
      'tests.test_rfc3125.suite',
      'tests.test_rfc3161.suite',
+     'tests.test_rfc3217.suite',
      'tests.test_rfc3274.suite',
      'tests.test_rfc3279.suite',
      'tests.test_rfc3280.suite',
@@ -39,6 +42,7 @@ suite = unittest.TestLoader().loadTestsFromNames(
      'tests.test_rfc3779.suite',
      'tests.test_rfc3820.suite',
      'tests.test_rfc3852.suite',
+     'tests.test_rfc3874.suite',
      'tests.test_rfc4010.suite',
      'tests.test_rfc4043.suite',
      'tests.test_rfc4055.suite',
@@ -46,6 +50,7 @@ suite = unittest.TestLoader().loadTestsFromNames(
      'tests.test_rfc4108.suite',
      'tests.test_rfc4210.suite',
      'tests.test_rfc4211.suite',
+     'tests.test_rfc4231.suite',
      'tests.test_rfc4334.suite',
      'tests.test_rfc4357.suite',
      'tests.test_rfc4387.suite',
@@ -90,8 +95,10 @@ suite = unittest.TestLoader().loadTestsFromNames(
      'tests.test_rfc6210.suite',
      'tests.test_rfc6211.suite',
      'tests.test_rfc6482.suite',
+     'tests.test_rfc6484.suite',
      'tests.test_rfc6486.suite',
      'tests.test_rfc6487.suite',
+     'tests.test_rfc6494.suite',
      'tests.test_rfc6664.suite',
      'tests.test_rfc6955.suite',
      'tests.test_rfc6960.suite',
@@ -127,7 +134,9 @@ suite = unittest.TestLoader().loadTestsFromNames(
      'tests.test_rfc8696.suite',
      'tests.test_rfc8702.suite',
      'tests.test_rfc8708.suite',
-     'tests.test_rfc8769.suite']
+     'tests.test_rfc8769.suite',
+     'tests.test_rfc8894.suite',
+     'tests.test_rfc8951.suite']
 )
 
 

--- a/tests/test_rfc2040.py
+++ b/tests/test_rfc2040.py
@@ -1,0 +1,67 @@
+#
+# This file is part of pyasn1-modules software.
+#
+# Created by Russ Housley
+# Copyright (c) 2021, Vigil Security, LLC
+# License: http://snmplabs.com/pyasn1/license.html
+#
+import sys
+import unittest
+
+from pyasn1.codec.der.decoder import decode as der_decoder
+from pyasn1.codec.der.encoder import encode as der_encoder
+
+from pyasn1_modules import pem
+from pyasn1_modules import rfc5652
+from pyasn1_modules import rfc2040
+
+
+class RC5EncryptedDataTestCase(unittest.TestCase):
+    pem_text = """\
+MEoGCSqGSIb3DQEHBqA9MDsCAQAwNgYJKoZIhvcNAQcBMB8GCCqGSIb3DQMIMBMC
+ARACARACAUAECAECAwQFBgcIgAja1r2p3+j36A==
+"""
+
+    def setUp(self):
+        self.asn1Spec = rfc5652.ContentInfo()
+
+    def testDerCodec(self):
+        substrate = pem.readBase64fromText(self.pem_text)
+        asn1Object, rest = der_decoder(substrate, asn1Spec=self.asn1Spec)
+
+        self.assertFalse(rest)
+        self.assertTrue(asn1Object.prettyPrint())
+        self.assertEqual(substrate, der_encoder(asn1Object))
+
+        self.assertEqual(rfc5652.id_encryptedData, asn1Object['contentType'])
+        ed, rest = der_decoder(
+            asn1Object['content'], asn1Spec=rfc5652.EncryptedData())
+        self.assertFalse(rest)
+        self.assertTrue(ed.prettyPrint())
+        self.assertEqual(asn1Object['content'], der_encoder(ed))
+
+        ai = ed['encryptedContentInfo']['contentEncryptionAlgorithm']
+        self.assertEqual(rfc2040.rc5_CBC, ai['algorithm'])
+        param, rest = der_decoder(
+            ai['parameters'], asn1Spec=rfc2040.RC5_CBC_Parameters())
+        self.assertFalse(rest)
+        self.assertTrue(param.prettyPrint())
+        self.assertEqual(ai['parameters'], der_encoder(param))
+
+        self.assertEqual(16, param['rounds'])
+
+    def testOpenTypes(self):
+        substrate = pem.readBase64fromText(self.pem_text)
+        asn1Object, rest = der_decoder(
+            substrate, asn1Spec=self.asn1Spec, decodeOpenTypes=True)
+
+        eci = asn1Object['content']['encryptedContentInfo']
+        ai = eci['contentEncryptionAlgorithm']
+        self.assertEqual(rfc2040.rc5_CBC, ai['algorithm'])
+        self.assertEqual(16, ai['parameters']['rounds'])
+
+
+suite = unittest.TestLoader().loadTestsFromModule(sys.modules[__name__])
+
+if __name__ == '__main__':
+    unittest.TextTestRunner(verbosity=2).run(suite)

--- a/tests/test_rfc2528.py
+++ b/tests/test_rfc2528.py
@@ -1,0 +1,82 @@
+#
+# This file is part of pyasn1-modules software.
+#
+# Created by Russ Housley
+# Copyright (c) 2021, Vigil Security, LLC
+# License: http://snmplabs.com/pyasn1/license.html
+#
+
+import sys
+import unittest
+
+from pyasn1.codec.der.decoder import decode as der_decoder
+from pyasn1.codec.der.encoder import encode as der_encoder
+from pyasn1.type import univ
+
+from pyasn1_modules import pem
+from pyasn1_modules import rfc5280
+from pyasn1_modules import rfc2528
+
+
+class KEACertificateTestCase(unittest.TestCase):
+    kea_cert_pem_text = """\
+MIICizCCAjOgAwIBAgIUY8xt3l0B9nIPWSpjs0hDJUJZmCgwCQYHKoZIzjgEAzA/
+MQswCQYDVQQGEwJVUzELMAkGA1UECBMCVkExEDAOBgNVBAcTB0hlcm5kb24xETAP
+BgNVBAoTCEJvZ3VzIENBMB4XDTE5MTAyMDIwMDkyMVoXDTIwMTAxOTIwMDkyMVow
+cDELMAkGA1UEBhMCVVMxCzAJBgNVBAgTAlZBMRAwDgYDVQQHEwdIZXJuZG9uMRAw
+DgYDVQQKEwdFeGFtcGxlMQ4wDAYDVQQDEwVBbGljZTEgMB4GCSqGSIb3DQEJARYR
+YWxpY2VAZXhhbXBsZS5jb20wgaAwFwYJYIZIAWUCAQEWBApc+PEn5ladbYizA4GE
+AAKBgB9Lc2QcoSW0E9/VnQ2xGBtpYh9MaDUBzIixbN8rhDwh0BBesD2TwHjzBpDM
+2PJ6DD1ZbBcz2M3vJaIKoZ8hA2EUtbbHX1BSnVfAdeqr5St5gfnuxSdloUjLQlWO
+rOYfpFVEp6hJoKAZiYfiXz0fohNXn8+fiU5k214byxlCPlU0o4GUMIGRMAsGA1Ud
+DwQEAwIDCDBCBglghkgBhvhCAQ0ENRYzVGhpcyBjZXJ0aWZpY2F0ZSBjYW5ub3Qg
+YmUgdHJ1c3RlZCBmb3IgYW55IHB1cnBvc2UuMB0GA1UdDgQWBBSE49bkPB9sQm27
+Rs2jgAPMyY6UCDAfBgNVHSMEGDAWgBTNSGUBg7KmB1sG/iOBDMRz5NG1ODAJBgcq
+hkjOOAQDA0cAMEQCIE9PWhUbnJVdNQcVYSc36BMZ+23uk2ITLsgSXtkScF6TAiAf
+TPnJ5Wym0hv2fOpnPPsWTgqvLFYfX27GGTquuOd/6A==
+"""
+
+    def setUp(self):
+        self.asn1Spec = rfc5280.Certificate()
+
+    def testDerCodec(self):
+        substrate = pem.readBase64fromText(self.kea_cert_pem_text)
+        asn1Object, rest = der_decoder(substrate, asn1Spec=self.asn1Spec)
+
+        self.assertFalse(rest)
+        self.assertTrue(asn1Object.prettyPrint())
+        self.assertEqual(substrate, der_encoder(asn1Object))
+
+        ai = asn1Object['tbsCertificate']['subjectPublicKeyInfo']['algorithm']
+        self.assertEqual(rfc2528.id_keyExchangeAlgorithm, ai['algorithm'])
+
+        param, rest = der_decoder(
+            ai['parameters'], asn1Spec=rfc2528.KEA_Parms_Id())
+        self.assertFalse(rest)
+        self.assertTrue(param.prettyPrint())
+        self.assertEqual(ai['parameters'], der_encoder(param))
+        
+        self.assertEqual(
+            univ.OctetString(hexValue='5cf8f127e6569d6d88b3'), param)
+
+    def testOpenTypes(self):
+        substrate = pem.readBase64fromText(self.kea_cert_pem_text)
+        asn1Object, rest = der_decoder(
+            substrate, asn1Spec=self.asn1Spec, decodeOpenTypes=True)
+
+        self.assertFalse(rest)
+        self.assertTrue(asn1Object.prettyPrint())
+        self.assertEqual(substrate, der_encoder(asn1Object))
+
+        ai = asn1Object['tbsCertificate']['subjectPublicKeyInfo']['algorithm']
+        self.assertEqual(rfc2528.id_keyExchangeAlgorithm, ai['algorithm'])
+
+        param = ai['parameters']
+        self.assertEqual(
+            univ.OctetString(hexValue='5cf8f127e6569d6d88b3'), param)
+
+
+suite = unittest.TestLoader().loadTestsFromModule(sys.modules[__name__])
+
+if __name__ == '__main__':
+    unittest.TextTestRunner(verbosity=2).run(suite)

--- a/tests/test_rfc3217.py
+++ b/tests/test_rfc3217.py
@@ -1,0 +1,73 @@
+#
+# This file is part of pyasn1-modules software.
+#
+# Created by Russ Housley
+# Copyright (c) 2021, Vigil Security, LLC
+# License: http://snmplabs.com/pyasn1/license.html
+#
+
+import sys
+import unittest
+
+from pyasn1.codec.der.decoder import decode as der_decoder
+from pyasn1.codec.der.encoder import encode as der_encoder
+
+from pyasn1.type import univ
+
+from pyasn1_modules import pem
+from pyasn1_modules import rfc3217
+from pyasn1_modules import rfc5751
+
+
+class WrapSMIMECapabilitiesTestCase(unittest.TestCase):
+    pem_text = "MCMwDwYLKoZIhvcNAQkQAwYFADAQBgsqhkiG9w0BCRADBwIBOg=="
+
+    def setUp(self):
+        self.asn1Spec = rfc5751.SMIMECapabilities()
+
+    def testDerCodec(self):
+        substrate = pem.readBase64fromText(self.pem_text)
+        asn1Object, rest = der_decoder(substrate, asn1Spec=self.asn1Spec)
+        self.assertFalse(rest)
+        self.assertTrue(asn1Object.prettyPrint())
+        self.assertEqual(substrate, der_encoder(asn1Object))
+
+        wrap_alg_count = 0
+        for cap in asn1Object:
+            if cap['capabilityID'] in rfc5751.smimeCapabilityMap.keys():
+                if cap['capabilityID'] == rfc3217.id_alg_CMS3DESwrap:
+                    wrap_alg_count += 1
+                if cap['capabilityID'] == rfc3217.id_alg_CMSRC2wrap:
+                    wrap_alg_count += 1
+                    asn1Spec = rfc5751.smimeCapabilityMap[cap['capabilityID']]
+                    param, rest = der_decoder(cap['parameters'],
+                        asn1Spec=asn1Spec)
+                    self.assertFalse(rest)
+                    self.assertTrue(param.prettyPrint())
+                    self.assertEqual(cap['parameters'], der_encoder(param))
+
+        self.assertEqual(2, wrap_alg_count)
+
+    def testOpenTypes(self):
+        substrate = pem.readBase64fromText(self.pem_text)
+        asn1Object, rest = der_decoder(
+            substrate, asn1Spec=self.asn1Spec, decodeOpenTypes=True)
+        self.assertFalse(rest)
+        self.assertTrue(asn1Object.prettyPrint())
+        self.assertEqual(substrate, der_encoder(asn1Object))
+
+        found_wrap_alg_param = False
+        for cap in asn1Object:
+            if cap['capabilityID'] == rfc3217.id_alg_CMSRC2wrap:
+                self.assertEqual(58, cap['parameters'])
+                found_wrap_alg_param = True
+
+        self.assertTrue(found_wrap_alg_param)
+
+
+suite = unittest.TestLoader().loadTestsFromModule(sys.modules[__name__])
+
+if __name__ == '__main__':
+    result = unittest.TextTestRunner(verbosity=2).run(suite)
+    sys.exit(not result.wasSuccessful())
+

--- a/tests/test_rfc3874.py
+++ b/tests/test_rfc3874.py
@@ -1,0 +1,67 @@
+#
+# This file is part of pyasn1-modules software.
+#
+# Created by Russ Housley
+# Copyright (c) 2021, Vigil Security, LLC
+# License: http://snmplabs.com/pyasn1/license.html
+#
+import sys
+import unittest
+
+from pyasn1.codec.der.decoder import decode as der_decoder
+from pyasn1.codec.der.encoder import encode as der_encoder
+
+from pyasn1.type import univ
+
+from pyasn1_modules import pem
+from pyasn1_modules import rfc5751
+from pyasn1_modules import rfc3874
+
+
+class SHA224SMIMECapabilitiesTestCase(unittest.TestCase):
+    pem_text = """\
+MEcwCQYFKw4DAhoFADANBglghkgBZQMEAgQFADANBglghkgBZQMEAgEFADANBglg
+hkgBZQMEAgIFADANBglghkgBZQMEAgMFAA==
+"""
+
+    def setUp(self):
+        self.asn1Spec = rfc5751.SMIMECapabilities()
+
+    def testDerCodec(self):
+        substrate = pem.readBase64fromText(self.pem_text)
+        asn1Object, rest = der_decoder(substrate, asn1Spec=self.asn1Spec)
+        self.assertFalse(rest)
+        self.assertTrue(asn1Object.prettyPrint())
+        self.assertEqual(substrate, der_encoder(asn1Object))
+
+        found = False
+        for cap in asn1Object:
+            if cap['capabilityID'] == rfc3874.id_sha224:
+                substrate = cap['parameters']
+                cap_p, rest = der_decoder(substrate, asn1Spec=univ.Null())
+                found = True
+
+        self.assertTrue(found)
+
+    def testOpenTypes(self):
+        substrate = pem.readBase64fromText(self.pem_text)
+        asn1Object, rest = der_decoder(
+            substrate, asn1Spec=self.asn1Spec, decodeOpenTypes=True)
+        self.assertFalse(rest)
+        self.assertTrue(asn1Object.prettyPrint())
+        self.assertEqual(substrate, der_encoder(asn1Object))
+
+        found = False
+        for cap in asn1Object:
+            if cap['capabilityID'] == rfc3874.id_sha224:
+                substrate = cap['parameters']
+                self.assertEqual(cap['parameters'], univ.Null(""))
+                found = True
+
+        self.assertTrue(found)
+
+
+suite = unittest.TestLoader().loadTestsFromModule(sys.modules[__name__])
+
+if __name__ == '__main__':
+    unittest.TextTestRunner(verbosity=2).run(suite)

--- a/tests/test_rfc4231.py
+++ b/tests/test_rfc4231.py
@@ -1,0 +1,78 @@
+#
+# This file is part of pyasn1-modules software.
+#
+# Created by Russ Housley
+# Copyright (c) 2020, Vigil Security, LLC
+# License: http://snmplabs.com/pyasn1/license.html
+#
+import sys
+import unittest
+
+from pyasn1.codec.der.decoder import decode as der_decoder
+from pyasn1.codec.der.encoder import encode as der_encoder
+
+from pyasn1.type import univ
+
+from pyasn1_modules import pem
+from pyasn1_modules import rfc5652
+from pyasn1_modules import rfc4231
+
+
+class AuthenticatedDataHMACTestCase(unittest.TestCase):
+    pem_text = """\
+MIIBPAYLKoZIhvcNAQkQAQKgggErMIIBJwIBADFromkCAQQwIwQQ+28rOVL9dEnS
+mPaKpLzZTRgPMjAyMDExMTAxMjAwMDBaMA0GCyqGSIb3DQEJEAMMBDAStUZBHNYL
+oY34HUBosaOl5d2XDHF6Bf/z344mbKUYO7HAiQk9Z9SPuW6Mouv96wEwDAYIKoZI
+hvcNAgkFAKELBglghkgBZQMEAgEwKwYJKoZIhvcNAQcBoB4EHFRoaXMgaXMgc29t
+ZSBzYW1wbGUgY29udGVudC6iSzAYBgkqhkiG9w0BCQMxCwYJKoZIhvcNAQcBMC8G
+CSqGSIb3DQEJBDEiBCDIdd8qQhBwSp7d27bfzIcEcRaPkE0YMxi78YSsCwReUwQg
+SKsIer5tGtrwyn32lCEg+97txfgu+ZVVfpyZm74euek=
+"""
+
+    def setUp(self):
+        self.asn1Spec = rfc5652.ContentInfo()
+
+    def testDerCodec(self):
+        substrate = pem.readBase64fromText(self.pem_text)
+        asn1Object, rest = der_decoder(substrate, asn1Spec=self.asn1Spec)
+
+        self.assertFalse(rest)
+        self.assertTrue(asn1Object.prettyPrint())
+        self.assertEqual(substrate, der_encoder(asn1Object))
+
+        ad, rest = der_decoder(
+            asn1Object['content'],
+            asn1Spec=rfc5652.AuthenticatedData())
+
+        self.assertFalse(rest)
+        self.assertTrue(ad.prettyPrint())
+        self.assertEqual(asn1Object['content'], der_encoder(ad))
+
+        self.assertEqual(0, ad['version'])
+        mac_alg = ad['macAlgorithm']
+        self.assertEqual(rfc4231.id_hmacWithSHA256, mac_alg['algorithm'])
+
+        param, rest = der_decoder(mac_alg['parameters'], asn1Spec=univ.Null())
+        assert not rest
+        assert der_encoder(param) == mac_alg['parameters']
+
+    def testOpenTypes(self):
+        substrate = pem.readBase64fromText(self.pem_text)
+        asn1Object, rest = der_decoder(substrate,
+                               asn1Spec=self.asn1Spec,
+                               decodeOpenTypes=True)
+
+        self.assertFalse(rest)
+        self.assertTrue(asn1Object.prettyPrint())
+        self.assertEqual(substrate, der_encoder(asn1Object))
+
+        ad = asn1Object['content']
+        self.assertEqual(0, ad['version'])
+        mac_alg = ad['macAlgorithm']
+        self.assertEqual(rfc4231.id_hmacWithSHA256, mac_alg['algorithm'])
+        self.assertEqual(univ.Null(""), mac_alg['parameters'])
+
+suite = unittest.TestLoader().loadTestsFromModule(sys.modules[__name__])
+
+if __name__ == '__main__':
+    unittest.TextTestRunner(verbosity=2).run(suite)

--- a/tests/test_rfc6484.py
+++ b/tests/test_rfc6484.py
@@ -1,0 +1,77 @@
+#
+# This file is part of pyasn1-modules software.
+#
+# Copyright (c) 2020, Vigil Security, LLC
+# License: http://snmplabs.com/pyasn1/license.html
+#
+import sys
+import unittest
+
+from pyasn1.codec.der.decoder import decode as der_decoder
+from pyasn1.codec.der.encoder import encode as der_encoder
+
+from pyasn1_modules import pem
+from pyasn1_modules import rfc5280
+from pyasn1_modules import rfc6484
+
+
+class CertificateExtnTestCase(unittest.TestCase):
+    pem_text = """\
+MIIECjCCAvKgAwIBAgICAMkwDQYJKoZIhvcNAQELBQAwFjEUMBIGA1UEAxMLcmlw
+ZS1uY2MtdGEwIBcNMTcxMTI4MTQzOTU1WhgPMjExNzExMjgxNDM5NTVaMBYxFDAS
+BgNVBAMTC3JpcGUtbmNjLXRhMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKC
+AQEA0URYSGqUz2myBsOzeW1jQ6NsxNvlLMyhWknvnl8NiBCs/T/S2XuNKQNZ+wBZ
+xIgPPV2pFBFeQAvoH/WK83HwA26V2siwm/MY2nKZ+Olw+wlpzlZ1p3Ipj2eNcKrm
+it8BwBC8xImzuCGaV0jkRB0GZ0hoH6Ml03umLprRsn6v0xOP0+l6Qc1ZHMFVFb38
+5IQ7FQQTcVIxrdeMsoyJq9eMkE6DoclHhF/NlSllXubASQ9KUWqJ0+Ot3QCXr4LX
+ECMfkpkVR2TZT+v5v658bHVs6ZxRD1b6Uk1uQKAyHUbn/tXvP8lrjAibGzVsXDT2
+L0x4Edx+QdixPgOji3gBMyL2VwIDAQABo4IBXjCCAVowHQYDVR0OBBYEFOhVKx/W
+0aT35ATG2OVoDR68Fj/DMA8GA1UdEwEB/wQFMAMBAf8wDgYDVR0PAQH/BAQDAgEG
+MIGxBggrBgEFBQcBCwSBpDCBoTA8BggrBgEFBQcwCoYwcnN5bmM6Ly9ycGtpLnJp
+cGUubmV0L3JlcG9zaXRvcnkvcmlwZS1uY2MtdGEubWZ0MDIGCCsGAQUFBzANhiZo
+dHRwczovL3JyZHAucmlwZS5uZXQvbm90aWZpY2F0aW9uLnhtbDAtBggrBgEFBQcw
+BYYhcnN5bmM6Ly9ycGtpLnJpcGUubmV0L3JlcG9zaXRvcnkvMBgGA1UdIAEB/wQO
+MAwwCgYIKwYBBQUHDgIwJwYIKwYBBQUHAQcBAf8EGDAWMAkEAgABMAMDAQAwCQQC
+AAIwAwMBADAhBggrBgEFBQcBCAEB/wQSMBCgDjAMMAoCAQACBQD/////MA0GCSqG
+SIb3DQEBCwUAA4IBAQAVgJjrZ3wFppC8Yk8D2xgzwSeWVT2vtYq96CQQsjaKb8nb
+eVz3DwcS3a7RIsevrNVGo43k3AGymg1ki+AWJjvHvJ+tSzCbn5+X6Z7AfYTf2g37
+xINVDHru0PTQUargSMBAz/MBNpFG8KThtT7WbJrK4+f/lvx0m8QOlYm2a17iXS3A
+GQJ6RHcq9ADscqGdumxmMMDjwED26bGaYdmru1hNIpwF//jVM/eRjBFoPHKFlx0k
+Ld/yoCQNmx1kW+xANx4uyWxi/DYgSV7Oynq+C60OucW+d8tIhkblh8+YfrmukJds
+V+vo2L72yerdbsP9xjqvhZrLKfsLZjYK4SdYYthi
+"""
+
+    def setUp(self):
+        self.asn1Spec = rfc5280.Certificate()
+
+    def testDerCodec(self):
+
+        substrate = pem.readBase64fromText(self.pem_text)
+        asn1Object, rest = der_decoder(substrate, asn1Spec=self.asn1Spec)
+
+        self.assertFalse(rest)
+        self.assertTrue(asn1Object.prettyPrint())
+        self.assertEqual(substrate, der_encoder(asn1Object))
+
+        found = False
+        for extn in asn1Object['tbsCertificate']['extensions']:
+            if extn['extnID'] == rfc5280.id_ce_certificatePolicies:
+                s = extn['extnValue']
+                pseq, rest = der_decoder(s, rfc5280.CertificatePolicies())
+        
+                self.assertFalse(rest)
+                self.assertTrue(pseq.prettyPrint())
+                self.assertEqual(s, der_encoder(pseq))
+
+                for pi in pseq:
+                    if pi['policyIdentifier'] == rfc6484.id_cp_ipAddr_asNumber:
+                        found = True
+
+        self.assertTrue(found)
+
+
+suite = unittest.TestLoader().loadTestsFromModule(sys.modules[__name__])
+
+if __name__ == '__main__':
+    result = unittest.TextTestRunner(verbosity=2).run(suite)
+    sys.exit(not result.wasSuccessful())

--- a/tests/test_rfc6494.py
+++ b/tests/test_rfc6494.py
@@ -1,0 +1,72 @@
+#
+# This file is part of pyasn1-modules software.
+#
+# Created by Russ Housley
+# Copyright (c) 2019, Vigil Security, LLC
+# License: http://snmplabs.com/pyasn1/license.html
+#
+import sys
+import unittest
+
+from pyasn1.codec.der.decoder import decode as der_decoder
+from pyasn1.codec.der.encoder import encode as der_encoder
+
+from pyasn1_modules import pem
+from pyasn1_modules import rfc5280
+from pyasn1_modules import rfc6494
+
+
+class CertificateTestCase(unittest.TestCase):
+    cert_pem_text = """\
+MIIDljCCAv+gAwIBAgIUV0x6DELQ4jdGSHcm0QFEbGWEj38wDQYJKoZIhvcNAQEF
+BQAwUTELMAkGA1UEBhMCVVMxCzAJBgNVBAgTAlZBMRAwDgYDVQQHEwdIZXJuZG9u
+MREwDwYDVQQKEwhCb2d1cyBDQTEQMA4GA1UEAxMHU0VORCBDQTAeFw0yMDEyMTEx
+NzExMTRaFw0yMTEyMTExNzExMTRaMF8xCzAJBgNVBAYTAlVTMQswCQYDVQQIDAJW
+QTESMBAGA1UECgwJQm9ndXMgSVNQMS8wLQYDVQQDDCZhZTEzMi00OC5pYWQtbXNl
+MDEtYWEtaWUxLmJvZ3VzaXNwLm5ldDCBnzANBgkqhkiG9w0BAQEFAAOBjQAwgYkC
+gYEA8+d2MFk/VwFZASBZqVQNYoKl82dV9EXZtlhv9XaXHQoBWwEsFIx3Vt4qvDVx
+R99EVq/8QadH4Duqe1kOXrjd/OR39hv6MxX1mVQKfnoslHpUl5SFl480xxeHKFdW
+9L2YORSO4V2E4U1++3YD5OAEiXBJNCIVIRnqv57DNdSAqRkCAwEAAaOCAVswggFX
+MB0GA1UdDgQWBBRwhJB73ODi5oatFF4kxyhezmNsrDCBjgYDVR0jBIGGMIGDgBQX
+yVDy3dzL9sHlz8eGrZsFyACVH6FVpFMwUTELMAkGA1UEBhMCVVMxCzAJBgNVBAgT
+AlZBMRAwDgYDVQQHEwdIZXJuZG9uMREwDwYDVQQKEwhCb2d1cyBDQTEQMA4GA1UE
+AxMHU0VORCBDQYIUT+ZI0j8ZF+hTMrNrp95OWSgX0NowDAYDVR0TAQH/BAIwADAL
+BgNVHQ8EBAMCB4AwEwYDVR0lBAwwCgYIKwYBBQUHAxcwMQYIKwYBBQUHAQcBAf8E
+IjAgMAsEAgABMAUDAwAKAjARBAIAAjALAwkAIAENuMr+vr4wQgYJYIZIAYb4QgEN
+BDUWM1RoaXMgY2VydGlmaWNhdGUgY2Fubm90IGJlIHRydXN0ZWQgZm9yIGFueSBw
+dXJwb3NlLjANBgkqhkiG9w0BAQUFAAOBgQBRpxWx42rSni3ApQ67zQfgh3SqLGNU
+gtht7mHlJpW0LPdT7tnnrbAyzQVlLd2I3twy4xaTC3Amc5TfHqEh8ocRhf8wfCnP
+a/TUx+t2ycyo8lQ495FoxYzpLYEJLCDIcUqkJY3Y30sPvYx5FEDrMKvWmp0yOvun
+Ydk2mhKOR6JwKQ==
+"""
+
+    def setUp(self):
+        self.asn1Spec = rfc5280.Certificate()
+
+    def testDerCodec(self):
+        substrate = pem.readBase64fromText(self.cert_pem_text)
+        asn1Object, rest = der_decoder(substrate, asn1Spec=self.asn1Spec)
+
+        self.assertFalse(rest)
+        self.assertTrue(asn1Object.prettyPrint())
+        self.assertEqual(substrate, der_encoder(asn1Object))
+
+        found = False
+        for extn in asn1Object['tbsCertificate']['extensions']:
+            if extn['extnID'] in rfc5280.certificateExtensionsMap:
+                extnValue, rest = der_decoder(
+                    extn['extnValue'],
+                    asn1Spec=rfc5280.certificateExtensionsMap[extn['extnID']])
+
+                self.assertEqual(extn['extnValue'], der_encoder(extnValue))
+
+                if extn['extnID'] == rfc5280.id_ce_extKeyUsage:
+                    self.assertTrue(rfc6494.id_kp_sendRouter, extnValue[0])
+                    found = True
+
+        self.assertTrue(found)
+
+suite = unittest.TestLoader().loadTestsFromModule(sys.modules[__name__])
+
+if __name__ == '__main__':
+    unittest.TextTestRunner(verbosity=2).run(suite)

--- a/tests/test_rfc6664.py
+++ b/tests/test_rfc6664.py
@@ -10,6 +10,8 @@ import unittest
 from pyasn1.codec.der.decoder import decode as der_decoder
 from pyasn1.codec.der.encoder import encode as der_encoder
 
+from pyasn1.type import univ
+
 from pyasn1_modules import pem
 from pyasn1_modules import rfc5480
 from pyasn1_modules import rfc5751
@@ -47,14 +49,15 @@ PQMBBwYFK4EEACIGBSuBBAAjMBoGCSqGSIb3DQEBCDANBglghkgBZQMEAgEFAA==
         for cap in asn1Object:
             if cap['capabilityID'] in rfc5751.smimeCapabilityMap.keys():
                 substrate = cap['parameters']
-                cap_p, rest = der_decoder(
-                    substrate, asn1Spec=rfc5751.smimeCapabilityMap[cap['capabilityID']])
-                self.assertFalse(rest)
-                self.assertTrue(cap_p.prettyPrint())
-                self.assertEqual(substrate, der_encoder(cap_p))
+                asn1Spec = rfc5751.smimeCapabilityMap[cap['capabilityID']]
+                cap_p, rest = der_decoder(substrate, asn1Spec=asn1Spec)
                 count += 1
+                if not cap_p == univ.Null(""):
+                    self.assertFalse(rest)
+                    self.assertTrue(cap_p.prettyPrint())
+                    self.assertEqual(substrate, der_encoder(cap_p))
 
-        self.assertEqual(8, count)
+        self.assertEqual(13, count)
 
     def testOpenTypes(self):
         substrate = pem.readBase64fromText(self.smime_capabilities_pem_text)

--- a/tests/test_rfc8737.py
+++ b/tests/test_rfc8737.py
@@ -1,0 +1,71 @@
+#
+# This file is part of pyasn1-modules software.
+#
+# Created by Russ Housley
+# Copyright (c) 2020, Vigil Security, LLC
+# License: http://snmplabs.com/pyasn1/license.html
+#
+import sys
+import unittest
+
+from pyasn1.codec.der.decoder import decode as der_decoder
+from pyasn1.codec.der.encoder import encode as der_encoder
+
+from pyasn1_modules import pem
+from pyasn1_modules import rfc5280
+from pyasn1_modules import rfc8737
+
+
+class ACMEIdentifierTestCase(unittest.TestCase):
+    pem_text = """\
+MIIDXDCCAkSgAwIBAgIUaKWDEVneTUkvvTOZB4f4Hhbfkj0wDQYJKoZIhvcNAQEL
+BQAwGzEZMBcGA1UEAxMQdGVzdC5leGFtcGxlLmNvbTAeFw0yMDEyMjkyMjA1MjFa
+Fw0yMTAxMDIyMjA1MjFaMBsxGTAXBgNVBAMTEHRlc3QuZXhhbXBsZS5jb20wggEi
+MA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC8vg/L5D+VSxSY4omMBkkZHlgg
+rvM9cMHmwkAFzQwkO022DCRvYPfkvFjzbR5YqwuuZyyAeUHCgp/arIUslXQJ39W5
+HEWtih/sHe5N/9u91IoDvP7Zn8OimXbC6YxKQvskJkIZ5r8Eqqwms3NIIwJ21FJz
+jI3iA8GRdc7oJgMplU8GjO1PsKnW+tePOuaM7XDDUvTAazhloZRSts42K+bnh90m
+vhyPZ57mDQ6EyplJU5MKZCSqzh3lfMKCwJgYEJk/CP7JwZc+/Y+ZkRQ5stXg/rTg
+wh3+tkLdYIgzfVMzTuNSePUA5AjJEDK/wugIAMF7co7iZ1HbEhvI8niebv0zAgMB
+AAGjgZcwgZQwMQYIKwYBBQUHAR8BAf8EIgQghzeHN4c3hzeHN4c3hzeHN4c3hzeH
+N4c3hzeHN4c3hzcwQgYJYIZIAYb4QgENBDUWM1RoaXMgY2VydGlmaWNhdGUgY2Fu
+bm90IGJlIHRydXN0ZWQgZm9yIGFueSBwdXJwb3NlLjAbBgNVHREEFDASghB0ZXN0
+LmV4YW1wbGUuY29tMA0GCSqGSIb3DQEBCwUAA4IBAQAZdlB0TAKlgAsVqCm+Bg1j
+iEA8A7ZKms6J/CYy6LB6oJPcUqVMmUMigEvWD2mIO4Q2cHwJ6Gn9Zf5jb0jhBPS2
+HYGJN2wVGYmWdyB4TOWRhu122iXpKGkQZ01+knP+ueVLqYvmRGx/V3sw12mbN+PB
+y+EhhFdfjfuY95qbo5yBmY7EQSKf7lXyUvFkPAtirj6lvzTEIshvS9qkj0XiMiO8
+6F/d2sVhPWpD3JOxhp0D+JEYcXwfwmn6OprRUTAvCFhpC+qkQOoTa37Xy65V0435
+LWIbHF0HSW/CxDQo22mHT+tMqd13NzlDN3HxurIEGU4fBjk/rMSxw/bAPf4O0QT3
+"""
+
+    def setUp(self):
+        self.asn1Spec = rfc5280.Certificate()
+
+    def testDerCodec(self):
+        substrate = pem.readBase64fromText(self.pem_text)
+        asn1Object, rest = der_decoder(substrate, asn1Spec=self.asn1Spec)
+
+        self.assertFalse(rest)
+        self.assertTrue(asn1Object.prettyPrint())
+        self.assertEqual(substrate, der_encoder(asn1Object))
+
+        found = False
+        for extn in asn1Object['tbsCertificate']['extensions']:
+           if extn['extnID'] == rfc8737.id_pe_acmeIdentifier:
+               self.assertTrue(extn['critical'])
+               self.assertIn(extn['extnID'], rfc5280.certificateExtensionsMap)
+               auth, rest = der_decoder(
+                   extn['extnValue'], asn1Spec=rfc8737.Authorization())
+               self.assertFalse(rest)
+               self.assertTrue(auth.prettyPrint())
+               self.assertEqual(extn['extnValue'], der_encoder(auth))
+               self.assertEqual(32, len(auth))
+               found = True
+
+        self.assertTrue(found)
+
+
+suite = unittest.TestLoader().loadTestsFromModule(sys.modules[__name__])
+
+if __name__ == '__main__':
+    unittest.TextTestRunner(verbosity=2).run(suite)

--- a/tests/test_rfc8894.py
+++ b/tests/test_rfc8894.py
@@ -1,0 +1,69 @@
+#
+# This file is part of pyasn1-modules software.
+#
+# Created by Russ Housley
+# Copyright (c) 2020, Vigil Security, LLC
+# License: http://snmplabs.com/pyasn1/license.html
+#
+import sys
+import unittest
+
+from pyasn1.codec.der.decoder import decode as der_decoder
+from pyasn1.codec.der.encoder import encode as der_encoder
+
+from pyasn1.type import char
+from pyasn1.type import univ
+
+from pyasn1_modules import pem
+from pyasn1_modules import rfc8894
+
+
+class IssuerAndSubjectTestCase(unittest.TestCase):
+    pem_text = """\
+MIGzMD8xCzAJBgNVBAYTAlVTMQswCQYDVQQIDAJWQTEQMA4GA1UEBwwHSGVybmRv
+bjERMA8GA1UECgwIQm9ndXMgQ0EwcDELMAkGA1UEBhMCVVMxCzAJBgNVBAgTAlZB
+MRAwDgYDVQQHEwdIZXJuZG9uMRAwDgYDVQQKEwdFeGFtcGxlMQ4wDAYDVQQDEwVB
+bGljZTEgMB4GCSqGSIb3DQEJARYRYWxpY2VAZXhhbXBsZS5jb20=
+"""
+
+    def setUp(self):
+        self.asn1Spec = rfc8894.IssuerAndSubject()
+
+    def testDerCodec(self):
+        substrate = pem.readBase64fromText(self.pem_text)
+        asn1Object, rest = der_decoder(substrate, asn1Spec=self.asn1Spec)
+
+        self.assertFalse(rest)
+        self.assertTrue(asn1Object.prettyPrint())
+        self.assertEqual(substrate, der_encoder(asn1Object))
+
+        emailAttr = asn1Object['subject']['rdnSequence'][5][0]
+        oid = univ.ObjectIdentifier('1.2.840.113549.1.9.1')
+        self.assertEqual(oid, emailAttr['type'])
+
+        email, rest = der_decoder(emailAttr['value'], asn1Spec=char.IA5String())
+        self.assertFalse(rest)
+        self.assertTrue(email.prettyPrint())
+        self.assertEqual(emailAttr['value'], der_encoder(email))
+
+        self.assertEqual('alice@example.com', email)
+
+    def testOpenTypes(self):
+        substrate = pem.readBase64fromText(self.pem_text)
+        asn1Object, rest = der_decoder(
+            substrate, asn1Spec=self.asn1Spec, decodeOpenTypes=True)
+
+        self.assertFalse(rest)
+        self.assertTrue(asn1Object.prettyPrint())
+        self.assertEqual(substrate, der_encoder(asn1Object))
+
+        emailAttr = asn1Object['subject']['rdnSequence'][5][0]
+        oid = univ.ObjectIdentifier('1.2.840.113549.1.9.1')
+        self.assertEqual(oid, emailAttr['type'])
+        self.assertEqual('alice@example.com', emailAttr['value'])
+
+
+suite = unittest.TestLoader().loadTestsFromModule(sys.modules[__name__])
+
+if __name__ == '__main__':
+    unittest.TextTestRunner(verbosity=2).run(suite)

--- a/tests/test_rfc8951.py
+++ b/tests/test_rfc8951.py
@@ -1,0 +1,91 @@
+#
+# This file is part of pyasn1-modules software.
+#
+# Created by Russ Housley
+# Copyright (c) 2020, Vigil Security, LLC
+# License: http://snmplabs.com/pyasn1/license.html
+#
+import sys
+import unittest
+
+from pyasn1.codec.der.decoder import decode as der_decoder
+from pyasn1.codec.der.encoder import encode as der_encoder
+from pyasn1.type import univ
+
+from pyasn1_modules import pem
+from pyasn1_modules import rfc5652
+from pyasn1_modules import rfc8951
+
+
+class CSRAttrsTestCase(unittest.TestCase):
+    pem_text = """\
+MEEGCSqGSIb3DQEJBzASBgcqhkjOPQIBMQcGBSuBBAAiMBYGCSqGSIb3DQEJDjEJ
+BgcrBgEBAQEWBggqhkjOPQQDAw==
+"""
+
+    the_oids = (
+        univ.ObjectIdentifier('1.2.840.113549.1.9.7'),
+        univ.ObjectIdentifier('1.2.840.10045.4.3.3')
+    )
+
+    the_attrTypes = (
+        univ.ObjectIdentifier('1.2.840.10045.2.1'),
+        univ.ObjectIdentifier('1.2.840.113549.1.9.14'),
+    )
+
+    the_attrVals = (
+        '1.3.132.0.34',
+        '1.3.6.1.1.1.1.22',
+    )
+
+    def setUp(self):
+        self.asn1Spec = rfc8951.CsrAttrs()
+
+    def testDerCodec(self):
+        substrate = pem.readBase64fromText(self.pem_text)
+        asn1Object, rest = der_decoder(substrate, asn1Spec=self.asn1Spec)
+
+        self.assertFalse(rest)
+        self.assertTrue(asn1Object.prettyPrint())
+        self.assertEqual(substrate, der_encoder(asn1Object))
+
+        for attr_or_oid in asn1Object:
+            if attr_or_oid.getName() == 'oid':
+                self.assertIn(attr_or_oid['oid'], self.the_oids)
+
+            if attr_or_oid.getName() == 'attribute':
+                self.assertIn(
+                    attr_or_oid['attribute']['attrType'], self.the_attrTypes)
+
+    def testOpenTypes(self):
+        openTypesMap = rfc5652.cmsAttributesMap.copy()
+
+        for at in self.the_attrTypes:
+            openTypesMap.update({at: univ.ObjectIdentifier()})
+
+        substrate = pem.readBase64fromText(self.pem_text)
+        asn1Object, rest = der_decoder(
+            substrate, asn1Spec=self.asn1Spec, openTypes=openTypesMap,
+            decodeOpenTypes=True)
+
+        self.assertFalse(rest)
+        self.assertTrue(asn1Object.prettyPrint())
+        self.assertEqual(substrate, der_encoder(asn1Object))
+
+        for attr_or_oid in asn1Object:
+            if attr_or_oid.getName() == 'attribute':
+                val = attr_or_oid['attribute']['attrValues'][0]
+                valString = val.prettyPrint()
+
+                aoo = attr_or_oid['attribute']['attrType']
+                if aoo == self.the_attrTypes[0]:
+                    self.assertEqual(self.the_attrVals[0], valString)
+
+                if aoo == self.the_attrTypes[1]:
+                    self.assertEqual(self.the_attrVals[1], valString)
+
+
+suite = unittest.TestLoader().loadTestsFromModule(sys.modules[__name__])
+
+if __name__ == '__main__':
+    unittest.TextTestRunner(verbosity=2).run(suite)


### PR DESCRIPTION
This includes improvements and new modules:
- Update RFC6960 to include Nonce size constraints from RFC8984
- Update RFC8018 to import AES_IV from RFC3565
- Add opentypes support for RFC4210 and RFC4211
- Update the SMIMECapabilities map in module for RFC5990
- Improve the opentypes testing for the RFC6664 module
- Add RFC2040 providing identifiers for the RC5 encryption algorithms
- Add RFC2528 providing identifiers for the Key Exchange Algorithm (KEA)
- Add RFC3217 providing identifiers for the Triple-DES and RC2 Key Wrapping
- Add RFC3874 providing identifiers for the SHA-224 hash algorithm
- Add RFC4231 providing identifiers for the HMAC-SHA-* algorithms
- Add RFC6484 providing the RPKI Certificate Policy Identifier
- Add RFC6494 providing SEcure Neighbor Discovery (SEND) EKU OIDs
- Add RFC8894 providing Simple Certificate Enrolment Protocol (SCEP)
- Add RFC8951 providing Enrollment over Secure Transport (EST) Clarifications