### PR TITLE
Include PKCS#1 v1.5 algorithm identifiers in RFC 4055

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -52,6 +52,7 @@ Revision 0.3.0, released XX-XX-2021
 - Add RFC5544 providing the TimeStampedData Content Type
 - Add RFC5055 providing Server-Based Certificate Validation Protocol (SCVP)
 - Add RFC5276 providing SCVP updates to convey Long-Term Evidence Records
+- Modified RFC4055 to include PKCS#1 v1.5 algorithm identifiers
 
 Revision 0.2.8, released 16-11-2019
 -----------------------------------

--- a/pyasn1_modules/rfc4055.py
+++ b/pyasn1_modules/rfc4055.py
@@ -2,10 +2,12 @@
 # This file is part of pyasn1-modules software.
 #
 # Created by Russ Housley with a very small amount of assistance from
-# asn1ate v.0.6.0.
+#   asn1ate v.0.6.0.
 # Modified by Russ Housley to add maps for opentypes.
+# Modified by Russ Housley to add PKCS#1 v1.5 algorithm identifiers, which
+#   are not in the ASN.1 module, but they are discussed in RFC 4055.
 #
-# Copyright (c) 2019, Vigil Security, LLC
+# Copyright (c) 2019-2021, Vigil Security, LLC
 # License: http://snmplabs.com/pyasn1/license.html
 #
 # Additional Algorithms and Identifiers for RSA Cryptography
@@ -78,6 +80,22 @@ sha384Identifier['parameters'] = univ.Null("")
 sha512Identifier = rfc5280.AlgorithmIdentifier()
 sha512Identifier['algorithm'] = id_sha512
 sha512Identifier['parameters'] = univ.Null("")
+
+sha224WithRSAEncryptionIdentifier = rfc5280.AlgorithmIdentifier()
+sha224WithRSAEncryptionIdentifier['algorithm'] = sha224WithRSAEncryption
+sha224WithRSAEncryptionIdentifier['parameters'] = univ.Null("")
+
+sha256WithRSAEncryptionIdentifier = rfc5280.AlgorithmIdentifier()
+sha256WithRSAEncryptionIdentifier['algorithm'] = sha256WithRSAEncryption
+sha256WithRSAEncryptionIdentifier['parameters'] = univ.Null("")
+
+sha384WithRSAEncryptionIdentifier = rfc5280.AlgorithmIdentifier()
+sha384WithRSAEncryptionIdentifier['algorithm'] = sha384WithRSAEncryption
+sha384WithRSAEncryptionIdentifier['parameters'] = univ.Null("")
+
+sha512WithRSAEncryptionIdentifier = rfc5280.AlgorithmIdentifier()
+sha512WithRSAEncryptionIdentifier['algorithm'] = sha512WithRSAEncryption
+sha512WithRSAEncryptionIdentifier['parameters'] = univ.Null("")
 
 mgf1SHA1Identifier = rfc5280.AlgorithmIdentifier()
 mgf1SHA1Identifier['algorithm'] = id_mgf1


### PR DESCRIPTION
Modified RFC4055 to include PKCS#1 v1.5 algorithm identifiers.  These identifiers are not in the ASN.1 module, but they are discussed in RFC 4055.  Resolves https://github.com/etingof/pyasn1-modules/issues/137